### PR TITLE
Add ... as get_placekey arguments to allow unnecessary cols

### DIFF
--- a/R/get_placekey.R
+++ b/R/get_placekey.R
@@ -26,7 +26,8 @@ get_placekey <- function(location_name = NULL, street_address = NULL,
                          iso_country_code = NULL,
                          strict_address_match = FALSE,
                          strict_name_match = FALSE,
-                         key = Sys.getenv("PLACEKEY_SECRET")) {
+                         key = Sys.getenv("PLACEKEY_SECRET"),
+                         ...) {
 
   UseMethod("get_placekey")
 
@@ -39,7 +40,8 @@ get_placekey.default <- function(location_name = NULL, street_address = NULL,
                          iso_country_code = NULL,
                          strict_address_match = FALSE,
                          strict_name_match = FALSE,
-                         key = Sys.getenv("PLACEKEY_SECRET")) {
+                         key = Sys.getenv("PLACEKEY_SECRET"),
+                          ...) {
 
 
   # cast postal_code to character just incase it is not.


### PR DESCRIPTION
Currently, throws an error if `get_placekey` is given a `data.frame` that has any columns not strictly necessary for the Placekey call. This PR fixes the problem by adding `...` as an argument to `get_placekey` and `get_placekey.data.frame`, which resolves the issue. 

Also changes the README to refer to `devtools::install_github()` instead of `devtools()`.